### PR TITLE
Move handling of FBS and Publizon endpoints in CI to settings

### DIFF
--- a/assets/all.settings.php
+++ b/assets/all.settings.php
@@ -58,6 +58,7 @@ if (getenv('CI')) {
   // mocking work. It does not support ignoring self-signed certificates from
   // Wiremock.
   $config['dpl_fbs.settings'] = ['host' => 'http://fbs-openplatform.dbc.dk'];
+  $config['dpl_publizon.settings'] = ['host' => 'http://pubhub-openplatform.test.dbc.dk'];
   $config['openid_connect.settings.adgangsplatformen']['settings']['authorization_endpoint'] = 'http://login.bib.dk/oauth/authorize';
   $config['openid_connect.settings.adgangsplatformen']['settings']['token_endpoint'] = 'http://login.bib.dk/oauth/token/';
   $config['openid_connect.settings.adgangsplatformen']['settings']['userinfo_endpoint'] = 'http://login.bib.dk/userinfo/';

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -363,14 +363,8 @@ class DplReactAppsController extends ControllerBase {
     $services = $react_apps_settings->get('services') ?? [];
 
     // Get base urls from other modules.
-    $services['fbs'] = ['base_url' => $fbs_settings->get('base_url') ?? 'https://fbs-openplatform.dbc.dk'];
-    $services['publizon'] = ['base_url' => $publizon_settings->get('base_url') ?? 'https://pubhub-openplatform.test.dbc.dk'];
-
-    // Make sure to use http urls in urls from other modules when running in CI.
-    if (getenv('CI')) {
-      $services['fbs']['base_url'] = 'http://fbs-openplatform.dbc.dk';
-      $services['publizon']['base_url'] = 'http://pubhub-openplatform.test.dbc.dk';
-    }
+    $services['fbs'] = ['base_url' => $fbs_settings->get('host') ?? 'https://fbs-openplatform.dbc.dk'];
+    $services['publizon'] = ['base_url' => $publizon_settings->get('host') ?? 'https://pubhub-openplatform.test.dbc.dk'];
 
     $urls = [];
     foreach ($services as $api => $definition) {


### PR DESCRIPTION
We try to keep all our environment checking code and configuration adjustments in setttings.php instead of application code.

Also note the changes in config names: FBS and Publizon uses host  instead of base_url.

We only have to insert one configuration in settings.php as it already contains config for FBS.